### PR TITLE
Feature resource bundles i18n

### DIFF
--- a/docs/design/i18n-resource-bundles.md
+++ b/docs/design/i18n-resource-bundles.md
@@ -1,0 +1,48 @@
+# i18n Resource Bundle Design
+
+## Key Naming Convention
+
+Keys follow the pattern `<screen>.<elementDescription>` using camelCase for both parts.
+
+| Segment | Values |
+|---------|--------|
+| `<screen>` | `welcome`, `mainWindow`, `game` |
+| `<elementDescription>` | camelCase description of the UI element (e.g. `title`, `startButton`) |
+
+**Examples:** `welcome.startButton`, `game.currentPlayer`, `mainWindow.title`
+
+New keys must use an existing screen prefix or introduce a new prefix agreed on by the team.
+
+## Required Key List (Week 1)
+
+| Key | English Value | Owning UI Class |
+|-----|--------------|-----------------|
+| `game.currentPlayer` | `Current Player:` | `GameStatsView` |
+| `mainWindow.title` | `Chess` | `MainView` |
+| `welcome.missingNameMessage` | `Please enter a name for both players.` | `WelcomeView` |
+| `welcome.missingNameTitle` | `Missing Name` | `WelcomeView` |
+| `welcome.player1Label` | `Player 1 name:` | `WelcomeView` |
+| `welcome.player2Label` | `Player 2 name:` | `WelcomeView` |
+| `welcome.startButton` | `Start Game` | `WelcomeView` |
+| `welcome.title` | `Chess — Welcome` | `WelcomeView` |
+
+All three bundle files (`MessagesBundle.properties`, `MessagesBundle_en_US.properties`,
+`MessagesBundle_es_US.properties`) contain every key in this table.
+
+## Locale Fallback Behavior
+
+Java `ResourceBundle.getBundle("MessagesBundle", locale)` searches for bundle files in
+the following order (most specific to least specific):
+
+1. `MessagesBundle_<language>_<country>.properties` (e.g. `MessagesBundle_en_US.properties`)
+2. `MessagesBundle_<language>.properties` (e.g. `MessagesBundle_en.properties`)
+3. `MessagesBundle.properties` (the default — ultimate fallback)
+
+If a key is absent from the locale-specific file, Java automatically supplies it from the
+next less-specific file in the chain. The default `MessagesBundle.properties` is the
+ultimate fallback: if a key is missing there, a `MissingResourceException` is thrown at
+runtime.
+
+**Policy:** Every required key must be present in `MessagesBundle.properties`. Locale-
+specific bundles may omit keys and rely on fallback, but having explicit values in each
+file is preferred to avoid silent fallback to a different language.

--- a/src/main/resources/MessagesBundle.properties
+++ b/src/main/resources/MessagesBundle.properties
@@ -1,0 +1,8 @@
+game.currentPlayer=Current Player:
+mainWindow.title=Chess
+welcome.missingNameMessage=Please enter a name for both players.
+welcome.missingNameTitle=Missing Name
+welcome.player1Label=Player 1 name:
+welcome.player2Label=Player 2 name:
+welcome.startButton=Start Game
+welcome.title=Chess — Welcome

--- a/src/main/resources/MessagesBundle_en_US.properties
+++ b/src/main/resources/MessagesBundle_en_US.properties
@@ -1,0 +1,8 @@
+game.currentPlayer=Current Player:
+mainWindow.title=Chess
+welcome.missingNameMessage=Please enter a name for both players.
+welcome.missingNameTitle=Missing Name
+welcome.player1Label=Player 1 name:
+welcome.player2Label=Player 2 name:
+welcome.startButton=Start Game
+welcome.title=Chess — Welcome

--- a/src/main/resources/MessagesBundle_es_US.properties
+++ b/src/main/resources/MessagesBundle_es_US.properties
@@ -1,0 +1,8 @@
+game.currentPlayer=Jugador actual:
+mainWindow.title=Ajedrez
+welcome.missingNameMessage=Por favor, ingresa un nombre para ambos jugadores.
+welcome.missingNameTitle=Nombre faltante
+welcome.player1Label=Nombre del jugador 1:
+welcome.player2Label=Nombre del jugador 2:
+welcome.startButton=Iniciar juego
+welcome.title=Ajedrez — Bienvenido

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -51,10 +53,11 @@ class MessagesBundleTest {
 
   @Test
   void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
-    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
-    assertEquals(new Locale("en", "US"), bundle.getLocale());
-    for (String key : REQUIRED_KEYS) {
-      assertTrue(bundle.containsKey(key), "en_US bundle missing key: " + key);
-    }
+    ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
+    ResourceBundle enUsBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
+    assertEquals(new Locale("en", "US"), enUsBundle.getLocale());
+    Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
+    Set<String> enUsKeys = new HashSet<>(Collections.list(enUsBundle.getKeys()));
+    assertEquals(defaultKeys, enUsKeys, "en_US bundle key set differs from default bundle key set");
   }
 }

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -46,7 +46,6 @@ class MessagesBundleTest {
 
   @Test
   void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
-    assertEquals(Locale.US, ResourceBundle.getBundle(BUNDLE_NAME, Locale.US).getLocale());
     assertSameKeysAsDefault(Locale.US);
   }
 
@@ -59,6 +58,7 @@ class MessagesBundleTest {
   private void assertSameKeysAsDefault(Locale locale) {
     ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
     ResourceBundle localeBundle = ResourceBundle.getBundle(BUNDLE_NAME, locale);
+    assertEquals(locale, localeBundle.getLocale(), "expected " + locale + " bundle to load but got fallback");
     Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
     Set<String> localeKeys = new HashSet<>(Collections.list(localeBundle.getKeys()));
     assertEquals(defaultKeys, localeKeys, locale + " bundle key set differs from default bundle key set");

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -41,11 +41,13 @@ class MessagesBundleTest {
 
   @Test
   void messagesBundle_EsUsBundle_ContainsSameKeysAsDefault() {
-    ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
-    ResourceBundle esUsBundle = ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US"));
-    Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
-    Set<String> esUsKeys = new HashSet<>(Collections.list(esUsBundle.getKeys()));
-    assertEquals(defaultKeys, esUsKeys, "es_US bundle key set differs from default bundle key set");
+    assertSameKeysAsDefault(new Locale("es", "US"));
+  }
+
+  @Test
+  void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
+    assertEquals(Locale.US, ResourceBundle.getBundle(BUNDLE_NAME, Locale.US).getLocale());
+    assertSameKeysAsDefault(Locale.US);
   }
 
   private void assertContainsAllRequiredKeys(ResourceBundle bundle) {
@@ -54,13 +56,11 @@ class MessagesBundleTest {
     }
   }
 
-  @Test
-  void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
+  private void assertSameKeysAsDefault(Locale locale) {
     ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
-    ResourceBundle enUsBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
-    assertEquals(Locale.US, enUsBundle.getLocale());
+    ResourceBundle localeBundle = ResourceBundle.getBundle(BUNDLE_NAME, locale);
     Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
-    Set<String> enUsKeys = new HashSet<>(Collections.list(enUsBundle.getKeys()));
-    assertEquals(defaultKeys, enUsKeys, "en_US bundle key set differs from default bundle key set");
+    Set<String> localeKeys = new HashSet<>(Collections.list(localeBundle.getKeys()));
+    assertEquals(defaultKeys, localeKeys, locale + " bundle key set differs from default bundle key set");
   }
 }

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -26,9 +26,11 @@ class MessagesBundleTest {
   );
 
   @Test
-  void messagesBundle_LoadWithLocaleUS_IsNotNull() {
+  void messagesBundle_LoadWithLocaleUS_HasExpectedTitle() {
     ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
-    assertNotNull(bundle);
+    String title = bundle.getString("mainWindow.title");
+    assertNotNull(title);
+    assertTrue(!title.isBlank(), "mainWindow.title should not be blank in en_US bundle");
   }
 
   @Test

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -1,0 +1,50 @@
+package ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class MessagesBundleTest {
+
+  private static final String BUNDLE_NAME = "MessagesBundle";
+
+  private static final Set<String> REQUIRED_KEYS = Set.of(
+      "game.currentPlayer",
+      "mainWindow.title",
+      "welcome.missingNameMessage",
+      "welcome.missingNameTitle",
+      "welcome.player1Label",
+      "welcome.player2Label",
+      "welcome.startButton",
+      "welcome.title"
+  );
+
+  @Test
+  void messagesBundle_LoadWithLocaleUS_IsNotNull() {
+    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
+    assertNotNull(bundle);
+  }
+
+  @Test
+  void messagesBundle_DefaultBundle_ContainsAllRequiredKeys() {
+    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
+    for (String key : REQUIRED_KEYS) {
+      assertTrue(bundle.containsKey(key), "Default bundle missing key: " + key);
+    }
+  }
+
+  @Test
+  void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
+    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
+    assertEquals(new Locale("en", "US"), bundle.getLocale());
+    for (String key : REQUIRED_KEYS) {
+      assertTrue(bundle.containsKey(key), "en_US bundle missing key: " + key);
+    }
+  }
+}

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -1,7 +1,6 @@
 package ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,7 +31,6 @@ class MessagesBundleTest {
   void messagesBundle_LoadWithLocaleUS_HasExpectedTitle() {
     ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
     String title = bundle.getString("mainWindow.title");
-    assertNotNull(title);
     assertFalse(title.isBlank(), "mainWindow.title should not be blank in en_US bundle");
   }
 

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -42,6 +42,14 @@ class MessagesBundleTest {
   }
 
   @Test
+  void messagesBundle_EsUsBundle_ContainsAllRequiredKeys() {
+    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US"));
+    for (String key : REQUIRED_KEYS) {
+      assertTrue(bundle.containsKey(key), "es_US bundle missing key: " + key);
+    }
+  }
+
+  @Test
   void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
     ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
     assertEquals(new Locale("en", "US"), bundle.getLocale());

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -55,7 +55,7 @@ class MessagesBundleTest {
   void messagesBundle_EnUsBundle_ContainsSameKeysAsDefault() {
     ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
     ResourceBundle enUsBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
-    assertEquals(new Locale("en", "US"), enUsBundle.getLocale());
+    assertEquals(Locale.US, enUsBundle.getLocale());
     Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
     Set<String> enUsKeys = new HashSet<>(Collections.list(enUsBundle.getKeys()));
     assertEquals(defaultKeys, enUsKeys, "en_US bundle key set differs from default bundle key set");

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -41,8 +41,12 @@ class MessagesBundleTest {
   }
 
   @Test
-  void messagesBundle_EsUsBundle_ContainsAllRequiredKeys() {
-    assertContainsAllRequiredKeys(ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US")));
+  void messagesBundle_EsUsBundle_ContainsSameKeysAsDefault() {
+    ResourceBundle defaultBundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
+    ResourceBundle esUsBundle = ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US"));
+    Set<String> defaultKeys = new HashSet<>(Collections.list(defaultBundle.getKeys()));
+    Set<String> esUsKeys = new HashSet<>(Collections.list(esUsBundle.getKeys()));
+    assertEquals(defaultKeys, esUsKeys, "es_US bundle key set differs from default bundle key set");
   }
 
   private void assertContainsAllRequiredKeys(ResourceBundle bundle) {

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -2,6 +2,7 @@ package ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
@@ -32,7 +33,7 @@ class MessagesBundleTest {
     ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.US);
     String title = bundle.getString("mainWindow.title");
     assertNotNull(title);
-    assertTrue(!title.isBlank(), "mainWindow.title should not be blank in en_US bundle");
+    assertFalse(title.isBlank(), "mainWindow.title should not be blank in en_US bundle");
   }
 
   @Test

--- a/src/test/java/ui/MessagesBundleTest.java
+++ b/src/test/java/ui/MessagesBundleTest.java
@@ -37,17 +37,17 @@ class MessagesBundleTest {
 
   @Test
   void messagesBundle_DefaultBundle_ContainsAllRequiredKeys() {
-    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT);
-    for (String key : REQUIRED_KEYS) {
-      assertTrue(bundle.containsKey(key), "Default bundle missing key: " + key);
-    }
+    assertContainsAllRequiredKeys(ResourceBundle.getBundle(BUNDLE_NAME, Locale.ROOT));
   }
 
   @Test
   void messagesBundle_EsUsBundle_ContainsAllRequiredKeys() {
-    ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US"));
+    assertContainsAllRequiredKeys(ResourceBundle.getBundle(BUNDLE_NAME, new Locale("es", "US")));
+  }
+
+  private void assertContainsAllRequiredKeys(ResourceBundle bundle) {
     for (String key : REQUIRED_KEYS) {
-      assertTrue(bundle.containsKey(key), "es_US bundle missing key: " + key);
+      assertTrue(bundle.containsKey(key), bundle.getLocale() + " bundle missing key: " + key);
     }
   }
 


### PR DESCRIPTION
All `I18n Week 1: Resource Bundle Structure` (https://github.com/nu-cs-sqe/course-project-20252603-team-22-20252603/issues/37) responsibilities were implemented.

- Established `MessagesBundle` as the resource bundle base name and `<screen>.<elementDescription>` as the key naming convention
- Produced the required key list covering welcome, main-window, and game-status text (8 keys across `WelcomeView`, `MainView`, and `GameStatsView`)
- Created `MessagesBundle.properties` (default fallback), `MessagesBundle_en_US.properties`, and `MessagesBundle_es_US.properties`, each containing all 8 required keys
- Audited `GameStatsView` for hardcoded user-visible strings and mapped each to a key in the required key list
- Documented locale fallback behavior: Java searches most-specific to least-specific bundle; `MessagesBundle.properties` is the ultimate fallback and must contain every required key

All methods developed via red-green TDD. `MessagesBundleTest` covers 4 cases across default bundle key coverage, en_US and es_US key-set parity with the default, and non-blank value assertion for a locale-specific load. Documentation added in `docs/design/i18n-resource-bundles.md` covering the key naming convention, the complete required key list with owning UI class, and locale fallback behavior.