### PR TITLE
Feature controller contract integration

### DIFF
--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -3,25 +3,25 @@ package domain.piece;
 import domain.Location;
 
 public class Queen extends Piece {
-    public Queen(PieceColor color) {
-        super(PieceType.QUEEN, color);
-        if (color == null) {
-            throw new IllegalArgumentException("color must not be null");
-        }
-    }
+	public Queen(PieceColor color) {
+		super(PieceType.QUEEN, color);
+		if (color == null) {
+			throw new IllegalArgumentException("color must not be null");
+		}
+	}
 
-    @Override
-    public Piece makeCopy() {
-        return new Queen(getColor());
-    }
+	@Override
+	public Piece makeCopy() {
+		return new Queen(getColor());
+	}
 
-    public boolean isValidMoveShape(Location from, Location to) {
-        if (from == null) {
-            throw new IllegalArgumentException("from must not be null");
-        }
-        if (to == null) {
-            throw new IllegalArgumentException("to must not be null");
-        }
-        return false;
-    }
+	public boolean isValidMoveShape(Location from, Location to) {
+		if (from == null) {
+			throw new IllegalArgumentException("from must not be null");
+		}
+		if (to == null) {
+			throw new IllegalArgumentException("to must not be null");
+		}
+		return false;
+	}
 }

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -1,5 +1,7 @@
 package domain.piece;
 
+import domain.Location;
+
 public class Queen extends Piece {
     public Queen(PieceColor color) {
         super(PieceType.QUEEN, color);
@@ -11,5 +13,15 @@ public class Queen extends Piece {
     @Override
     public Piece makeCopy() {
         return new Queen(getColor());
+    }
+
+    public boolean isValidMoveShape(Location from, Location to) {
+        if (from == null) {
+            throw new IllegalArgumentException("from must not be null");
+        }
+        if (to == null) {
+            throw new IllegalArgumentException("to must not be null");
+        }
+        return false; // implementation owned by issue #14
     }
 }

--- a/src/main/java/domain/piece/Queen.java
+++ b/src/main/java/domain/piece/Queen.java
@@ -22,6 +22,6 @@ public class Queen extends Piece {
         if (to == null) {
             throw new IllegalArgumentException("to must not be null");
         }
-        return false; // implementation owned by issue #14
+        return false;
     }
 }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -5,29 +5,29 @@ import domain.Location;
 import domain.piece.Piece;
 
 public class BoardController {
-    private BoardView boardView;
-    private Board board;
+	private BoardView boardView;
+	private Board board;
 
-    public BoardController() {
-        this.board = new Board();
-    }
+	public BoardController() {
+		this.board = new Board();
+	}
 
-    void setBoardView(BoardView boardView) {
-        this.boardView = boardView;
-    }
+	void setBoardView(BoardView boardView) {
+		this.boardView = boardView;
+	}
 
-    public void handleSquareClick(Location location) {
-        // TODO
-        System.out.println("TEST: Square clicked at " + location.getX() + ", " + location.getY());
-    }
+	public void handleSquareClick(Location location) {
+		// TODO
+		System.out.println("TEST: Square clicked at " + location.getX() + ", " + location.getY());
+	}
 
-    public Piece[][] getBoardSnapshot() {
-        return this.board.getSnapshot();
-    }
+	public Piece[][] getBoardSnapshot() {
+		return this.board.getSnapshot();
+	}
 
-    protected void repaintBoardView() {
-        if (boardView != null) {
-            boardView.repaint();
-        }
-    }
+	protected void repaintBoardView() {
+		if (boardView != null) {
+			boardView.repaint();
+		}
+	}
 }

--- a/src/main/java/ui/BoardController.java
+++ b/src/main/java/ui/BoardController.java
@@ -24,4 +24,10 @@ public class BoardController {
     public Piece[][] getBoardSnapshot() {
         return this.board.getSnapshot();
     }
+
+    protected void repaintBoardView() {
+        if (boardView != null) {
+            boardView.repaint();
+        }
+    }
 }

--- a/src/test/java/domain/QueenTests.java
+++ b/src/test/java/domain/QueenTests.java
@@ -1,6 +1,5 @@
 package domain;
 
-import domain.Location;
 import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import domain.piece.Piece;

--- a/src/test/java/domain/QueenTests.java
+++ b/src/test/java/domain/QueenTests.java
@@ -14,119 +14,119 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueenTests {
-    @Test
-    public void QueenConstructor_BlackColor_SetsTypeAndColor() {
-        Queen queen = new Queen(PieceColor.BLACK);
+	@Test
+	public void QueenConstructor_BlackColor_SetsTypeAndColor() {
+		Queen queen = new Queen(PieceColor.BLACK);
 
-        assertEquals(PieceType.QUEEN, queen.getType());
-        assertEquals(PieceColor.BLACK, queen.getColor());
-    }
+		assertEquals(PieceType.QUEEN, queen.getType());
+		assertEquals(PieceColor.BLACK, queen.getColor());
+	}
 
-    @Test
-    public void QueenConstructor_WhiteColor_SetsTypeAndColor() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenConstructor_WhiteColor_SetsTypeAndColor() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertEquals(PieceType.QUEEN, queen.getType());
-        assertEquals(PieceColor.WHITE, queen.getColor());
-    }
+		assertEquals(PieceType.QUEEN, queen.getType());
+		assertEquals(PieceColor.WHITE, queen.getColor());
+	}
 
-    @Test
-    public void QueenConstructor_NullColor_ThrowsIllegalArgumentException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new Queen(null));
+	@Test
+	public void QueenConstructor_NullColor_ThrowsIllegalArgumentException() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new Queen(null));
 
-        assertEquals("color must not be null", exception.getMessage());
-    }
+		assertEquals("color must not be null", exception.getMessage());
+	}
 
-    @Test
-    public void QueenMakeCopy_BlackQueen_ReturnsDistinctQueenWithSameTypeAndColor() {
-        Queen queen = new Queen(PieceColor.BLACK);
+	@Test
+	public void QueenMakeCopy_BlackQueen_ReturnsDistinctQueenWithSameTypeAndColor() {
+		Queen queen = new Queen(PieceColor.BLACK);
 
-        Piece copy = queen.makeCopy();
+		Piece copy = queen.makeCopy();
 
-        assertNotSame(queen, copy);
-        assertInstanceOf(Queen.class, copy);
-        assertEquals(PieceType.QUEEN, copy.getType());
-        assertEquals(PieceColor.BLACK, copy.getColor());
-    }
+		assertNotSame(queen, copy);
+		assertInstanceOf(Queen.class, copy);
+		assertEquals(PieceType.QUEEN, copy.getType());
+		assertEquals(PieceColor.BLACK, copy.getColor());
+	}
 
-    @Test
-    public void QueenMakeCopy_WhiteQueen_ReturnsDistinctQueenWithSameTypeAndColor() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenMakeCopy_WhiteQueen_ReturnsDistinctQueenWithSameTypeAndColor() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        Piece copy = queen.makeCopy();
+		Piece copy = queen.makeCopy();
 
-        assertNotSame(queen, copy);
-        assertInstanceOf(Queen.class, copy);
-        assertEquals(PieceType.QUEEN, copy.getType());
-        assertEquals(PieceColor.WHITE, copy.getColor());
-    }
+		assertNotSame(queen, copy);
+		assertInstanceOf(Queen.class, copy);
+		assertEquals(PieceType.QUEEN, copy.getType());
+		assertEquals(PieceColor.WHITE, copy.getColor());
+	}
 
-    @Test
-    public void QueenMakeCopy_NullColorQueen_ThrowsIllegalArgumentException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new Queen(null));
+	@Test
+	public void QueenMakeCopy_NullColorQueen_ThrowsIllegalArgumentException() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new Queen(null));
 
-        assertEquals("color must not be null", exception.getMessage());
-    }
+		assertEquals("color must not be null", exception.getMessage());
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_StraightLineHorizontal_ReturnsTrue() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_StraightLineHorizontal_ReturnsTrue() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertTrue(queen.isValidMoveShape(new Location(0, 3), new Location(5, 3)));
-    }
+		assertTrue(queen.isValidMoveShape(new Location(0, 3), new Location(5, 3)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_StraightLineVertical_ReturnsTrue() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_StraightLineVertical_ReturnsTrue() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertTrue(queen.isValidMoveShape(new Location(4, 0), new Location(4, 7)));
-    }
+		assertTrue(queen.isValidMoveShape(new Location(4, 0), new Location(4, 7)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_DiagonalMove_ReturnsTrue() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_DiagonalMove_ReturnsTrue() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertTrue(queen.isValidMoveShape(new Location(0, 0), new Location(3, 3)));
-    }
+		assertTrue(queen.isValidMoveShape(new Location(0, 0), new Location(3, 3)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_SameSquare_ReturnsFalse() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_SameSquare_ReturnsFalse() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertFalse(queen.isValidMoveShape(new Location(3, 3), new Location(3, 3)));
-    }
+		assertFalse(queen.isValidMoveShape(new Location(3, 3), new Location(3, 3)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_KnightShapeMove_ReturnsFalse() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_KnightShapeMove_ReturnsFalse() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(1, 2)));
-    }
+		assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(1, 2)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_OutOfBoundsDestination_ReturnsFalse() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_OutOfBoundsDestination_ReturnsFalse() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(8, 0)));
-    }
+		assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(8, 0)));
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_NullFrom_ThrowsIllegalArgumentException() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_NullFrom_ThrowsIllegalArgumentException() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> queen.isValidMoveShape(null, new Location(3, 3)));
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> queen.isValidMoveShape(null, new Location(3, 3)));
 
-        assertEquals("from must not be null", exception.getMessage());
-    }
+		assertEquals("from must not be null", exception.getMessage());
+	}
 
-    @Test
-    public void QueenIsValidMoveShape_NullTo_ThrowsIllegalArgumentException() {
-        Queen queen = new Queen(PieceColor.WHITE);
+	@Test
+	public void QueenIsValidMoveShape_NullTo_ThrowsIllegalArgumentException() {
+		Queen queen = new Queen(PieceColor.WHITE);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> queen.isValidMoveShape(new Location(0, 0), null));
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> queen.isValidMoveShape(new Location(0, 0), null));
 
-        assertEquals("to must not be null", exception.getMessage());
-    }
+		assertEquals("to must not be null", exception.getMessage());
+	}
 }

--- a/src/test/java/domain/QueenTests.java
+++ b/src/test/java/domain/QueenTests.java
@@ -1,5 +1,6 @@
 package domain;
 
+import domain.Location;
 import domain.piece.PieceColor;
 import domain.piece.PieceType;
 import domain.piece.Piece;
@@ -7,9 +8,11 @@ import domain.piece.Queen;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QueenTests {
     @Test
@@ -64,5 +67,67 @@ public class QueenTests {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new Queen(null));
 
         assertEquals("color must not be null", exception.getMessage());
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_StraightLineHorizontal_ReturnsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertTrue(queen.isValidMoveShape(new Location(0, 3), new Location(5, 3)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_StraightLineVertical_ReturnsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertTrue(queen.isValidMoveShape(new Location(4, 0), new Location(4, 7)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_DiagonalMove_ReturnsTrue() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertTrue(queen.isValidMoveShape(new Location(0, 0), new Location(3, 3)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_SameSquare_ReturnsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertFalse(queen.isValidMoveShape(new Location(3, 3), new Location(3, 3)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_KnightShapeMove_ReturnsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(1, 2)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_OutOfBoundsDestination_ReturnsFalse() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        assertFalse(queen.isValidMoveShape(new Location(0, 0), new Location(8, 0)));
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_NullFrom_ThrowsIllegalArgumentException() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> queen.isValidMoveShape(null, new Location(3, 3)));
+
+        assertEquals("from must not be null", exception.getMessage());
+    }
+
+    @Test
+    public void QueenIsValidMoveShape_NullTo_ThrowsIllegalArgumentException() {
+        Queen queen = new Queen(PieceColor.WHITE);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> queen.isValidMoveShape(new Location(0, 0), null));
+
+        assertEquals("to must not be null", exception.getMessage());
     }
 }


### PR DESCRIPTION
All `Integration Testing Week 1: Controller and UI Refresh Contract` (https://github.com/nu-cs-sqe/course-project-20252603-team-22-20252603/issues/29) responsibilities were implemented.

- Defined `BoardController.repaintBoardView()` as the testability seam for UI refresh: the method delegates to `boardView.repaint()` when a view is present and does nothing (rather than throwing) when no view is wired, so integration tests can subclass `BoardController` and override `repaintBoardView()` with a spy without depending on Swing rendering
- Confirmed `BoardController.getBoardSnapshot()` delegates directly to `Board.getSnapshot()` and reflects board state at the time of the call; the snapshot contract is documented — callers receive whatever `Board` returns, and snapshot defensiveness is `Board`'s responsibility
- Locked the `Queen.isValidMoveShape(Location from, Location to)` contract signature; the method rejects null arguments with `IllegalArgumentException` and currently returns a stub `false` so that the integration test skeleton can reference the method without requiring a complete movement implementation
- Authored the full `QueenTests.isValidMoveShape` suite (8 cases: horizontal straight line, vertical straight line, diagonal move, same square, knight-shape move, out-of-bounds destination, null `from`, null `to`) as failing TDD tests that define the expected behavior for the owner of issue 14 to implement