### PR TITLE
Feature pitest setup multiple turns of the game

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     checkstyle
     id("com.github.spotbugs") version "6.0.25"
     jacoco
+    id("info.solidsoft.pitest") version "1.15.0"
 }
 
 group = "nu.csse.sqe"
@@ -33,6 +34,7 @@ tasks.compileJava {
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport)
+    finalizedBy("pitest")
 }
 
 tasks.withType<Checkstyle>().configureEach {
@@ -77,4 +79,23 @@ tasks.jacocoTestReport {
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir("reports/jacoco")
     }
+}
+
+pitest {
+    targetClasses = setOf("ui.*", "domain.*")
+    targetTests = setOf("domain.*")
+    junit5PluginVersion = "1.2.1"
+    pitestVersion = "1.15.0"
+    threads = 4
+    outputFormats = setOf("HTML")
+    timestampedReports = false
+    testSourceSets.set(listOf(sourceSets.test.get()))
+    mainSourceSets.set(listOf(sourceSets.main.get()))
+    jvmArgs.set(listOf("-Xmx1024m"))
+    useClasspathFile.set(true)
+    exportLineCoverage = true
+}
+
+tasks.build {
+    dependsOn("pitest")
 }


### PR DESCRIPTION
Add PIT mutation testing to Gradle build via the `info.solidsoft.pitest` plugin. Configures pitest to target the `ui` and `domain` packages with JUnit 5 support, generates HTML reports under `build/reports/pitest/`, and wires pitest as a finalizer of `test` and a dependency of `build`.