### PR TITLE
Feature controller setup integration

### DIFF
--- a/src/main/java/domain/GameState.java
+++ b/src/main/java/domain/GameState.java
@@ -1,0 +1,5 @@
+package domain;
+
+public enum GameState {
+  WHITE_TURN, BLACK_TURN
+}

--- a/src/main/java/ui/GameStatsView.java
+++ b/src/main/java/ui/GameStatsView.java
@@ -13,7 +13,7 @@ public class GameStatsView extends JPanel {
   }
 
   public GameStatsView(String player1Name, String player2Name, GameState initialState) {
-    currentPlayerLabel = new JLabel("Current Player: " + player1Name);
+    this(player1Name, player2Name);
   }
 
   public void updateCurrentPlayerLabel(String playerName) {

--- a/src/main/java/ui/GameStatsView.java
+++ b/src/main/java/ui/GameStatsView.java
@@ -1,7 +1,22 @@
 package ui;
 
+import domain.GameState;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 public class GameStatsView extends JPanel {
-    public GameStatsView(String player1Name, String player2Name) {}
+
+  private JLabel currentPlayerLabel;
+
+  public GameStatsView(String player1Name, String player2Name) {
+    currentPlayerLabel = new JLabel("Current Player: " + player1Name);
+  }
+
+  public GameStatsView(String player1Name, String player2Name, GameState initialState) {
+    currentPlayerLabel = new JLabel("Current Player: " + player1Name);
+  }
+
+  public void updateCurrentPlayerLabel(String playerName) {
+    currentPlayerLabel.setText("Current Player: " + playerName);
+  }
 }

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -14,62 +14,75 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GameSetupIntegrationTests {
 
+  private static final int BOARD_SIZE = 8;
+  private static final int ROOK_COL_QUEEN_SIDE = 0;
+  private static final int KNIGHT_COL_QUEEN_SIDE = 1;
+  private static final int BISHOP_COL_QUEEN_SIDE = 2;
+  private static final int QUEEN_COL = 3;
+  private static final int KING_COL = 4;
+  private static final int BISHOP_COL_KING_SIDE = 5;
+  private static final int KNIGHT_COL_KING_SIDE = 6;
+  private static final int ROOK_COL_KING_SIDE = 7;
+  private static final int BLACK_BACK_RANK = 0;
+  private static final int BLACK_PAWN_RANK = 1;
+  private static final int WHITE_BACK_RANK = 7;
+
   // --- Black back rank (row 0) ---
 
   @Test
   public void BoardSnapshot_BlackBackRankCol0_IsBlackRook() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.ROOK, snapshot[0][0].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][0].getColor());
+    assertEquals(PieceType.ROOK, snapshot[BLACK_BACK_RANK][ROOK_COL_QUEEN_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][ROOK_COL_QUEEN_SIDE].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol1_IsBlackKnight() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.KNIGHT, snapshot[0][1].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][1].getColor());
+    assertEquals(PieceType.KNIGHT, snapshot[BLACK_BACK_RANK][KNIGHT_COL_QUEEN_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][KNIGHT_COL_QUEEN_SIDE].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol2_IsBlackBishop() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.BISHOP, snapshot[0][2].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][2].getColor());
+    assertEquals(PieceType.BISHOP, snapshot[BLACK_BACK_RANK][BISHOP_COL_QUEEN_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][BISHOP_COL_QUEEN_SIDE].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol3_IsBlackQueen() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.QUEEN, snapshot[0][3].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][3].getColor());
+    assertEquals(PieceType.QUEEN, snapshot[BLACK_BACK_RANK][QUEEN_COL].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][QUEEN_COL].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol4_IsBlackKing() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.KING, snapshot[0][4].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][4].getColor());
+    assertEquals(PieceType.KING, snapshot[BLACK_BACK_RANK][KING_COL].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][KING_COL].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol5_IsBlackBishop() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.BISHOP, snapshot[0][5].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][5].getColor());
+    assertEquals(PieceType.BISHOP, snapshot[BLACK_BACK_RANK][BISHOP_COL_KING_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][BISHOP_COL_KING_SIDE].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol6_IsBlackKnight() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.KNIGHT, snapshot[0][6].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][6].getColor());
+    assertEquals(PieceType.KNIGHT, snapshot[BLACK_BACK_RANK][KNIGHT_COL_KING_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][KNIGHT_COL_KING_SIDE].getColor());
   }
 
   @Test
   public void BoardSnapshot_BlackBackRankCol7_IsBlackRook() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.ROOK, snapshot[0][7].getType());
-    assertEquals(PieceColor.BLACK, snapshot[0][7].getColor());
+    assertEquals(PieceType.ROOK, snapshot[BLACK_BACK_RANK][ROOK_COL_KING_SIDE].getType());
+    assertEquals(PieceColor.BLACK, snapshot[BLACK_BACK_RANK][ROOK_COL_KING_SIDE].getColor());
   }
 
   // --- Row 1 — black pawns ---
@@ -77,10 +90,10 @@ public class GameSetupIntegrationTests {
   @Test
   public void BoardSnapshot_Row1AllCols_AreBlackPawns() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    for (int col = 0; col < 8; col++) {
-      assertEquals(PieceType.PAWN, snapshot[1][col].getType(),
+    for (int col = 0; col < BOARD_SIZE; col++) {
+      assertEquals(PieceType.PAWN, snapshot[BLACK_PAWN_RANK][col].getType(),
           "Expected PAWN at row 1 col " + col);
-      assertEquals(PieceColor.BLACK, snapshot[1][col].getColor(),
+      assertEquals(PieceColor.BLACK, snapshot[BLACK_PAWN_RANK][col].getColor(),
           "Expected BLACK at row 1 col " + col);
     }
   }
@@ -94,19 +107,19 @@ public class GameSetupIntegrationTests {
 
   @Test
   public void BoardController_GetBoardSnapshot_ReturnsEightRows() {
-    assertEquals(8, new BoardController().getBoardSnapshot().length);
+    assertEquals(BOARD_SIZE, new BoardController().getBoardSnapshot().length);
   }
 
   @Test
   public void BoardController_GetBoardSnapshot_ReturnsEightColumns() {
-    assertEquals(8, new BoardController().getBoardSnapshot()[0].length);
+    assertEquals(BOARD_SIZE, new BoardController().getBoardSnapshot()[0].length);
   }
 
   @Test
   public void BoardController_GetBoardSnapshotRow7Col4_IsWhiteKing() {
     Piece[][] snapshot = new BoardController().getBoardSnapshot();
-    assertEquals(PieceType.KING, snapshot[7][4].getType());
-    assertEquals(PieceColor.WHITE, snapshot[7][4].getColor());
+    assertEquals(PieceType.KING, snapshot[WHITE_BACK_RANK][KING_COL].getType());
+    assertEquals(PieceColor.WHITE, snapshot[WHITE_BACK_RANK][KING_COL].getColor());
   }
 
   // --- GameStatsView ---

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -1,0 +1,118 @@
+package integration;
+
+import domain.GameState;
+import domain.piece.PieceColor;
+import domain.piece.PieceType;
+import domain.piece.Piece;
+import org.junit.jupiter.api.Test;
+import ui.BoardController;
+import ui.GameStatsView;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class GameSetupIntegrationTests {
+
+  // --- Black back rank (row 0) ---
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol0_IsBlackRook() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.ROOK, snapshot[0][0].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][0].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol1_IsBlackKnight() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.KNIGHT, snapshot[0][1].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][1].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol2_IsBlackBishop() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.BISHOP, snapshot[0][2].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][2].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol3_IsBlackQueen() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.QUEEN, snapshot[0][3].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][3].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol4_IsBlackKing() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.KING, snapshot[0][4].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][4].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol5_IsBlackBishop() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.BISHOP, snapshot[0][5].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][5].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol6_IsBlackKnight() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.KNIGHT, snapshot[0][6].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][6].getColor());
+  }
+
+  @Test
+  public void BoardSnapshot_BlackBackRankCol7_IsBlackRook() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.ROOK, snapshot[0][7].getType());
+    assertEquals(PieceColor.BLACK, snapshot[0][7].getColor());
+  }
+
+  // --- Row 1 — black pawns ---
+
+  @Test
+  public void BoardSnapshot_Row1AllCols_AreBlackPawns() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    for (int col = 0; col < 8; col++) {
+      assertEquals(PieceType.PAWN, snapshot[1][col].getType(),
+          "Expected PAWN at row 1 col " + col);
+      assertEquals(PieceColor.BLACK, snapshot[1][col].getColor(),
+          "Expected BLACK at row 1 col " + col);
+    }
+  }
+
+  // --- Controller snapshot shape ---
+
+  @Test
+  public void BoardController_GetBoardSnapshot_ReturnsNonNull() {
+    assertNotNull(new BoardController().getBoardSnapshot());
+  }
+
+  @Test
+  public void BoardController_GetBoardSnapshot_ReturnsEightRows() {
+    assertEquals(8, new BoardController().getBoardSnapshot().length);
+  }
+
+  @Test
+  public void BoardController_GetBoardSnapshot_ReturnsEightColumns() {
+    assertEquals(8, new BoardController().getBoardSnapshot()[0].length);
+  }
+
+  @Test
+  public void BoardController_GetBoardSnapshotRow7Col4_IsWhiteKing() {
+    Piece[][] snapshot = new BoardController().getBoardSnapshot();
+    assertEquals(PieceType.KING, snapshot[7][4].getType());
+    assertEquals(PieceColor.WHITE, snapshot[7][4].getColor());
+  }
+
+  // --- GameStatsView ---
+
+  @Test
+  public void GameStatsView_InitializedWithGameStateWhiteTurn_DoesNotThrow() {
+    assertDoesNotThrow(() -> new GameStatsView("Alice", "Bob", GameState.WHITE_TURN));
+  }
+}


### PR DESCRIPTION
All `Integration Testing Week 2: Black-Side Piece Placement and Controller Snapshot` responsibilities were implemented.

- Created `GameState` enum (`WHITE_TURN`, `BLACK_TURN`) to unblock integration test compilation; matches the contract established in PR 45
- Added `GameState` constructor to `GameStatsView` and wired `JLabel` field and `updateCurrentPlayerLabel` to align with PR #45 shape
- Created `GameSetupIntegrationTests` with 14 cases covering:
  - Black back-rank assertions: every square in row 0 is the correct `PieceType` and `PieceColor.BLACK` (ROOK, KNIGHT, BISHOP, QUEEN, KING, BISHOP, KNIGHT, ROOK)
  - Row 1 black pawn sweep: all 8 squares are `PieceType.PAWN` and `PieceColor.BLACK`
  - Controller snapshot shape: `getBoardSnapshot()` is non-null, 8 rows, 8 columns
  - Controller snapshot content: `snapshot[7][4]` is `PieceType.KING` and `PieceColor.WHITE`
  - `GameStatsView` no-throw: `new GameStatsView("Alice", "Bob", GameState.WHITE_TURN)` does not throw

## Gradle check status

`bash ./gradlew test` will **not fully pass on this branch**. The 13 snapshot and placement tests are intentionally failing: `Board.getSnapshot()` currently returns `null` — the fault is in `Board.java`, owned by (`feature-board-setup-integration`, issue #61). These tests are in the TDD red phase and will turn green once issue #61 implementation is merged. The `GameStatsView` no-throw test passes immediately. All 199 existing unit tests continue to pass.