### PR TITLE
Feature piece setup integration

### DIFF
--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -145,9 +145,13 @@ public class GameSetupIntegrationTests {
 
   @Test
   void pieceColor_EnumDefinition_HasExactlyTwoValues() {
+    assertEquals(2, PieceColor.values().length);
+  }
+
+  @Test
+  void pieceColor_EnumOrdinals_BlackPrecedesWhite() {
     PieceColor[] values = PieceColor.values();
 
-    assertEquals(2, values.length);
     assertEquals(PieceColor.BLACK, values[0]);
     assertEquals(PieceColor.WHITE, values[1]);
   }

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -18,6 +18,11 @@ public class GameSetupIntegrationTests {
   private static final int MIDDLE_ROW_START = 2;
   private static final int MIDDLE_ROW_END = 5;
   private static final int[] PIECE_ROWS = {0, 1, 6, 7};
+  private static final int WHITE_BACK_RANK_ROW = 7;
+  private static final int WHITE_PAWN_ROW = 6;
+  private static final int ROOK_COL = 0;
+  private static final int KNIGHT_COL = 1;
+  private static final int BISHOP_COL = 2;
 
   @Test
   void boardSetup_InitialBoard_SnapshotIsNonNull() {
@@ -85,21 +90,21 @@ public class GameSetupIntegrationTests {
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col0IsWhiteRook() {
-    assertWhiteBackRankPiece(0, PieceType.ROOK);
+    assertWhiteBackRankPiece(ROOK_COL, PieceType.ROOK);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col1IsWhiteKnight() {
-    assertWhiteBackRankPiece(1, PieceType.KNIGHT);
+    assertWhiteBackRankPiece(KNIGHT_COL, PieceType.KNIGHT);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col2IsWhiteBishop() {
-    assertWhiteBackRankPiece(2, PieceType.BISHOP);
+    assertWhiteBackRankPiece(BISHOP_COL, PieceType.BISHOP);
   }
 
   private void assertWhiteBackRankPiece(int col, PieceType expectedType) {
-    Piece p = new Board().getSnapshot()[7][col];
+    Piece p = new Board().getSnapshot()[WHITE_BACK_RANK_ROW][col];
     assertEquals(expectedType, p.getType());
     assertEquals(PieceColor.WHITE, p.getColor());
   }
@@ -109,9 +114,9 @@ public class GameSetupIntegrationTests {
     Piece[][] snapshot = new Board().getSnapshot();
 
     for (int col = 0; col < BOARD_SIZE; col++) {
-      Piece p = snapshot[6][col];
-      assertEquals(PieceType.PAWN, p.getType(), "Expected PAWN at [6][" + col + "]");
-      assertEquals(PieceColor.WHITE, p.getColor(), "Expected WHITE at [6][" + col + "]");
+      Piece p = snapshot[WHITE_PAWN_ROW][col];
+      assertEquals(PieceType.PAWN, p.getType(), "Expected PAWN at [" + WHITE_PAWN_ROW + "][" + col + "]");
+      assertEquals(PieceColor.WHITE, p.getColor(), "Expected WHITE at [" + WHITE_PAWN_ROW + "][" + col + "]");
     }
   }
 

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -104,14 +104,18 @@ public class GameSetupIntegrationTests {
   }
 
   private void assertWhiteBackRankPiece(int col, PieceType expectedType) {
-    Piece p = new Board().getSnapshot()[WHITE_BACK_RANK_ROW][col];
+    Board board = new Board();
+    Piece[][] snapshot = board.getSnapshot();
+
+    Piece p = snapshot[WHITE_BACK_RANK_ROW][col];
     assertEquals(expectedType, p.getType());
     assertEquals(PieceColor.WHITE, p.getColor());
   }
 
   @Test
   void boardSetup_InitialBoard_WhitePawnRowIsAllWhitePawns() {
-    Piece[][] snapshot = new Board().getSnapshot();
+    Board board = new Board();
+    Piece[][] snapshot = board.getSnapshot();
 
     for (int col = 0; col < BOARD_SIZE; col++) {
       Piece p = snapshot[WHITE_PAWN_ROW][col];

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -59,6 +59,12 @@ public class GameSetupIntegrationTests {
         assertNull(snapshot[row][col]);
       }
     }
+  }
+
+  @Test
+  void boardSetup_InitialBoard_PieceRowsArePopulated() {
+    Board board = new Board();
+    Piece[][] snapshot = board.getSnapshot();
 
     for (int row : PIECE_ROWS) {
       for (int col = 0; col < BOARD_SIZE; col++) {

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -18,8 +18,10 @@ public class GameSetupIntegrationTests {
   private static final int MIDDLE_ROW_START = 2;
   private static final int MIDDLE_ROW_END = 5;
   private static final int[] PIECE_ROWS = {0, 1, 6, 7};
-  private static final int WHITE_BACK_RANK_ROW = 7;
+  private static final int BLACK_BACK_RANK_ROW = 0;
+  private static final int BLACK_PAWN_ROW = 1;
   private static final int WHITE_PAWN_ROW = 6;
+  private static final int WHITE_BACK_RANK_ROW = 7;
   private static final int ROOK_COL = 0;
   private static final int KNIGHT_COL = 1;
   private static final int BISHOP_COL = 2;
@@ -90,26 +92,31 @@ public class GameSetupIntegrationTests {
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col0IsWhiteRook() {
-    assertWhiteBackRankPiece(ROOK_COL, PieceType.ROOK);
+    assertBackRankPiece(WHITE_BACK_RANK_ROW, ROOK_COL, PieceType.ROOK, PieceColor.WHITE);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col1IsWhiteKnight() {
-    assertWhiteBackRankPiece(KNIGHT_COL, PieceType.KNIGHT);
+    assertBackRankPiece(WHITE_BACK_RANK_ROW, KNIGHT_COL, PieceType.KNIGHT, PieceColor.WHITE);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col2IsWhiteBishop() {
-    assertWhiteBackRankPiece(BISHOP_COL, PieceType.BISHOP);
+    assertBackRankPiece(WHITE_BACK_RANK_ROW, BISHOP_COL, PieceType.BISHOP, PieceColor.WHITE);
   }
 
-  private void assertWhiteBackRankPiece(int col, PieceType expectedType) {
+  @Test
+  void boardSetup_InitialBoard_SnapshotRow0Col0IsBlackRook() {
+    assertBackRankPiece(BLACK_BACK_RANK_ROW, ROOK_COL, PieceType.ROOK, PieceColor.BLACK);
+  }
+
+  private void assertBackRankPiece(int row, int col, PieceType expectedType, PieceColor expectedColor) {
     Board board = new Board();
     Piece[][] snapshot = board.getSnapshot();
 
-    Piece p = snapshot[WHITE_BACK_RANK_ROW][col];
+    Piece p = snapshot[row][col];
     assertEquals(expectedType, p.getType());
-    assertEquals(PieceColor.WHITE, p.getColor());
+    assertEquals(expectedColor, p.getColor());
   }
 
   @Test
@@ -121,6 +128,18 @@ public class GameSetupIntegrationTests {
       Piece p = snapshot[WHITE_PAWN_ROW][col];
       assertEquals(PieceType.PAWN, p.getType(), "Expected PAWN at [" + WHITE_PAWN_ROW + "][" + col + "]");
       assertEquals(PieceColor.WHITE, p.getColor(), "Expected WHITE at [" + WHITE_PAWN_ROW + "][" + col + "]");
+    }
+  }
+
+  @Test
+  void boardSetup_InitialBoard_BlackPawnRowIsAllBlackPawns() {
+    Board board = new Board();
+    Piece[][] snapshot = board.getSnapshot();
+
+    for (int col = 0; col < BOARD_SIZE; col++) {
+      Piece p = snapshot[BLACK_PAWN_ROW][col];
+      assertEquals(PieceType.PAWN, p.getType(), "Expected PAWN at [" + BLACK_PAWN_ROW + "][" + col + "]");
+      assertEquals(PieceColor.BLACK, p.getColor(), "Expected BLACK at [" + BLACK_PAWN_ROW + "][" + col + "]");
     }
   }
 

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -85,25 +85,22 @@ public class GameSetupIntegrationTests {
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col0IsWhiteRook() {
-    Piece p = new Board().getSnapshot()[7][0];
-
-    assertEquals(PieceType.ROOK, p.getType());
-    assertEquals(PieceColor.WHITE, p.getColor());
+    assertWhiteBackRankPiece(0, PieceType.ROOK);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col1IsWhiteKnight() {
-    Piece p = new Board().getSnapshot()[7][1];
-
-    assertEquals(PieceType.KNIGHT, p.getType());
-    assertEquals(PieceColor.WHITE, p.getColor());
+    assertWhiteBackRankPiece(1, PieceType.KNIGHT);
   }
 
   @Test
   void boardSetup_InitialBoard_SnapshotRow7Col2IsWhiteBishop() {
-    Piece p = new Board().getSnapshot()[7][2];
+    assertWhiteBackRankPiece(2, PieceType.BISHOP);
+  }
 
-    assertEquals(PieceType.BISHOP, p.getType());
+  private void assertWhiteBackRankPiece(int col, PieceType expectedType) {
+    Piece p = new Board().getSnapshot()[7][col];
+    assertEquals(expectedType, p.getType());
     assertEquals(PieceColor.WHITE, p.getColor());
   }
 

--- a/src/test/java/integration/GameSetupIntegrationTests.java
+++ b/src/test/java/integration/GameSetupIntegrationTests.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import domain.Board;
 import domain.GameState;
 import domain.piece.Piece;
+import domain.piece.PieceColor;
+import domain.piece.PieceType;
 import org.junit.jupiter.api.Test;
 
 public class GameSetupIntegrationTests {
@@ -73,5 +75,49 @@ public class GameSetupIntegrationTests {
     Piece[][] second = board.getSnapshot();
 
     assertNotSame(first, second);
+  }
+
+  @Test
+  void boardSetup_InitialBoard_SnapshotRow7Col0IsWhiteRook() {
+    Piece p = new Board().getSnapshot()[7][0];
+
+    assertEquals(PieceType.ROOK, p.getType());
+    assertEquals(PieceColor.WHITE, p.getColor());
+  }
+
+  @Test
+  void boardSetup_InitialBoard_SnapshotRow7Col1IsWhiteKnight() {
+    Piece p = new Board().getSnapshot()[7][1];
+
+    assertEquals(PieceType.KNIGHT, p.getType());
+    assertEquals(PieceColor.WHITE, p.getColor());
+  }
+
+  @Test
+  void boardSetup_InitialBoard_SnapshotRow7Col2IsWhiteBishop() {
+    Piece p = new Board().getSnapshot()[7][2];
+
+    assertEquals(PieceType.BISHOP, p.getType());
+    assertEquals(PieceColor.WHITE, p.getColor());
+  }
+
+  @Test
+  void boardSetup_InitialBoard_WhitePawnRowIsAllWhitePawns() {
+    Piece[][] snapshot = new Board().getSnapshot();
+
+    for (int col = 0; col < BOARD_SIZE; col++) {
+      Piece p = snapshot[6][col];
+      assertEquals(PieceType.PAWN, p.getType(), "Expected PAWN at [6][" + col + "]");
+      assertEquals(PieceColor.WHITE, p.getColor(), "Expected WHITE at [6][" + col + "]");
+    }
+  }
+
+  @Test
+  void pieceColor_EnumDefinition_HasExactlyTwoValues() {
+    PieceColor[] values = PieceColor.values();
+
+    assertEquals(2, values.length);
+    assertEquals(PieceColor.BLACK, values[0]);
+    assertEquals(PieceColor.WHITE, values[1]);
   }
 }


### PR DESCRIPTION
## Summary

- Creates `GameSetupIntegrationTests` with integration tests verifying the initial board snapshot against `Board`'s documented starting position
- Asserts `snapshot[7][0]`, `[7][1]`, and `[7][2]` are `WHITE` `ROOK`, `KNIGHT`, and `BISHOP` respectively (via shared `assertBackRankPiece` helper)
- Asserts `snapshot[0][0]` is a `BLACK` `ROOK` (black back rank coverage)
- Asserts all 8 squares in row 6 are `WHITE` `PAWN`
- Asserts all 8 squares in row 1 are `BLACK` `PAWN`
- Asserts `PieceColor` enum has exactly two values; ordinal order (`BLACK` before `WHITE`) is a separate test
- Reviewed `BoardView.drawPieces()` coordinate convention against `Board`'s `pieces[row][col]` storage — no mismatch found